### PR TITLE
fix: retrieve touched accounts using `debug_traceTransaction` RPC

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,8 @@ sparseth [--rpc <url>] [--config <path>] [--network <name>] [--checkpoint <hash>
 
 ### Options
 
-`--rpc <url>` URL of the Ethereum RPC endpoint to connect to (default: `ws://localhost:8545`).
+`--rpc <url>` URL of the Ethereum RPC endpoint to connect to (default: `ws://localhost:8545`). Important: Make sure that
+your RPC endpoint supports the `debug_traceTransaction` method with the `prestateTracer` available.
 
 `--config <path>` Path to the configuration file defining all monitored accounts (default: `config.yaml`).
 

--- a/execution/ethclient/client.go
+++ b/execution/ethclient/client.go
@@ -231,11 +231,11 @@ func (ec *Client) GetTransactionsAtBlock(ctx context.Context, blockNum *big.Int)
 //
 // The prestate tracer returns the accounts necessary to
 // execute the specified transaction.
-func (ec *Client) GetTransactionTrace(ctx context.Context, hash common.Hash) (*TransactionTrace, error) {
+func (ec *Client) GetTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error) {
 	var result *TransactionTrace
-	err := ec.c.CallContext(ctx, &result, "debug_traceTransaction", hash.Hex(), prestateTracer)
+	err := ec.c.CallContext(ctx, &result, "debug_traceTransaction", txHash.Hex(), prestateTracer)
 	if err != nil {
-		return nil, fmt.Errorf("failed to trace transaction %s: %w", hash.Hex(), err)
+		return nil, fmt.Errorf("failed to trace transaction %s: %w", txHash.Hex(), err)
 	}
 	return result, nil
 }

--- a/execution/ethclient/client.go
+++ b/execution/ethclient/client.go
@@ -240,69 +240,6 @@ func (ec *Client) GetTransactionTrace(ctx context.Context, txHash common.Hash) (
 	return result, nil
 }
 
-// CreateAccessList creates an access list for the
-// specified transaction based on the state at the
-// specified block number.
-func (ec *Client) CreateAccessList(ctx context.Context, tx *types.Transaction, from common.Address, blockNum *big.Int) (*types.AccessList, error) {
-	type req struct {
-		From                 common.Address               `json:"from"`
-		To                   *common.Address              `json:"to"`
-		Value                *hexutil.Big                 `json:"value,omitempty"`
-		GasPrice             *hexutil.Big                 `json:"gasPrice,omitempty"`
-		MaxFeePerGas         *hexutil.Big                 `json:"maxFeePerGas,omitempty"`
-		MaxPriorityFeePerGas *hexutil.Big                 `json:"maxPriorityFeePerGas,omitempty"`
-		MaxFeePerBlobGas     *hexutil.Big                 `json:"maxFeePerBlobGas,omitempty"`
-		BlobVersionedHashes  []common.Hash                `json:"blobVersionedHashes,omitempty"`
-		AccessList           types.AccessList             `json:"accessList,omitempty"`
-		AuthorizationList    []types.SetCodeAuthorization `json:"authorizationList,omitempty"`
-		Input                hexutil.Bytes                `json:"input,omitempty"`
-	}
-
-	arg := &req{
-		From: from,
-		To:   tx.To(),
-	}
-	if val := tx.Value(); val != nil {
-		arg.Value = (*hexutil.Big)(val)
-	}
-	if input := tx.Data(); len(input) > 0 {
-		arg.Input = input
-	}
-	if gasPrice := tx.GasPrice(); gasPrice != nil {
-		arg.GasPrice = (*hexutil.Big)(gasPrice)
-	}
-	if gasFeeCap := tx.GasFeeCap(); gasFeeCap != nil {
-		arg.MaxFeePerGas = (*hexutil.Big)(gasFeeCap)
-	}
-	if gasTipCap := tx.GasTipCap(); gasTipCap != nil {
-		arg.MaxPriorityFeePerGas = (*hexutil.Big)(gasTipCap)
-	}
-	if blobGasFeeCap := tx.BlobGasFeeCap(); blobGasFeeCap != nil {
-		arg.MaxFeePerBlobGas = (*hexutil.Big)(blobGasFeeCap)
-	}
-	if blobHashes := tx.BlobHashes(); blobHashes != nil {
-		arg.BlobVersionedHashes = blobHashes
-	}
-	if accessList := tx.AccessList(); accessList != nil {
-		arg.AccessList = accessList
-	}
-	if authList := tx.SetCodeAuthorizations(); authList != nil {
-		arg.AuthorizationList = authList
-	}
-
-	type rpcAccessList struct {
-		AccessList *types.AccessList `json:"accessList"`
-	}
-
-	var accessList *rpcAccessList
-	err := ec.c.CallContext(ctx, &accessList, "eth_createAccessList", arg, toBlockNumArg(blockNum))
-	if err != nil {
-		return nil, fmt.Errorf("failed to create access list: %w", err)
-	}
-
-	return accessList.AccessList, nil
-}
-
 // toBlockNumArg converts a *big.Int block number
 // to a hex-encoded string suitable for RPC calls.
 func toBlockNumArg(blockNum *big.Int) string {

--- a/execution/ethclient/client.go
+++ b/execution/ethclient/client.go
@@ -13,6 +13,15 @@ import (
 	"strings"
 )
 
+var (
+	// prestateTracer is a tracer that returns
+	// the accounts necessary to re-execute a
+	// transaction.
+	prestateTracer = map[string]string{
+		"tracer": "prestateTracer",
+	}
+)
+
 // Client is a wrapper for the
 // Ethereum RPC API.
 type Client struct {
@@ -214,6 +223,21 @@ func (ec *Client) GetTransactionsAtBlock(ctx context.Context, blockNum *big.Int)
 		return nil, fmt.Errorf("block %s not found", blockNum)
 	}
 	return block.Txs, err
+}
+
+// GetTransactionTrace retrieves the transaction trace
+// with a pre-state tracer for the specified transaction
+// hash.
+//
+// The prestate tracer returns the accounts necessary to
+// execute the specified transaction.
+func (ec *Client) GetTransactionTrace(ctx context.Context, hash common.Hash) (*TransactionTrace, error) {
+	var result *TransactionTrace
+	err := ec.c.CallContext(ctx, &result, "debug_traceTransaction", hash.Hex(), prestateTracer)
+	if err != nil {
+		return nil, fmt.Errorf("failed to trace transaction %s: %w", hash.Hex(), err)
+	}
+	return result, nil
 }
 
 // CreateAccessList creates an access list for the

--- a/execution/ethclient/provider.go
+++ b/execution/ethclient/provider.go
@@ -50,9 +50,4 @@ type Provider interface {
 	// Note that the returned trace is not verified, and hence
 	// may not be complete or valid.
 	GetTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error)
-
-	// CreateAccessList creates an access list for the
-	// specified transaction based on the state at the
-	// specified block number.
-	CreateAccessList(ctx context.Context, tx *TransactionWithSender, blockNum *big.Int) (*types.AccessList, error)
 }

--- a/execution/ethclient/provider.go
+++ b/execution/ethclient/provider.go
@@ -40,6 +40,17 @@ type Provider interface {
 	// specified block, otherwise an error will be returned.
 	GetCodeAtBlock(ctx context.Context, acc common.Address, head *types.Header) ([]byte, error)
 
+	// GetTransactionTrace retrieves the transaction trace
+	// with a pre-state tracer for the specified transaction
+	// hash.
+	//
+	// The prestate tracer returns the accounts necessary to
+	// execute the specified transaction.
+	//
+	// Note that the returned trace is not verified, and hence
+	// may not be complete or valid.
+	GetTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error)
+
 	// CreateAccessList creates an access list for the
 	// specified transaction based on the state at the
 	// specified block number.

--- a/execution/ethclient/rpc_provider.go
+++ b/execution/ethclient/rpc_provider.go
@@ -66,6 +66,16 @@ func (p *RpcProvider) GetCodeAtBlock(ctx context.Context, acc common.Address, he
 	return p.acc.getCodeAtBlock(ctx, acc, head)
 }
 
+// GetTransactionTrace retrieves the transaction trace
+// with a pre-state tracer for the specified transaction
+// hash.
+//
+// The prestate tracer returns the accounts necessary to
+// execute the specified transaction.
+func (p *RpcProvider) GetTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error) {
+	return p.tx.getTransactionTrace(ctx, txHash)
+}
+
 // CreateAccessList creates an access list for the
 // specified transaction based on the state at the
 // specified block number.

--- a/execution/ethclient/rpc_provider.go
+++ b/execution/ethclient/rpc_provider.go
@@ -75,10 +75,3 @@ func (p *RpcProvider) GetCodeAtBlock(ctx context.Context, acc common.Address, he
 func (p *RpcProvider) GetTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error) {
 	return p.tx.getTransactionTrace(ctx, txHash)
 }
-
-// CreateAccessList creates an access list for the
-// specified transaction based on the state at the
-// specified block number.
-func (p *RpcProvider) CreateAccessList(ctx context.Context, tx *TransactionWithSender, blockNum *big.Int) (*types.AccessList, error) {
-	return p.tx.createAccessList(ctx, tx, blockNum)
-}

--- a/execution/ethclient/tx_provider.go
+++ b/execution/ethclient/tx_provider.go
@@ -58,10 +58,3 @@ func (p *txProvider) getTxsAtBlock(ctx context.Context, header *types.Header) ([
 func (p *txProvider) getTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error) {
 	return p.c.GetTransactionTrace(ctx, txHash)
 }
-
-// createAccessList creates an access list for the
-// specified transaction based on the state at the
-// specified block number.
-func (p *txProvider) createAccessList(ctx context.Context, tx *TransactionWithSender, blockNum *big.Int) (*types.AccessList, error) {
-	return p.c.CreateAccessList(ctx, tx.Tx, tx.From, blockNum)
-}

--- a/execution/ethclient/tx_provider.go
+++ b/execution/ethclient/tx_provider.go
@@ -6,7 +6,6 @@ import (
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
-	"math/big"
 )
 
 // txProvider provides verified

--- a/execution/ethclient/tx_provider.go
+++ b/execution/ethclient/tx_provider.go
@@ -3,6 +3,7 @@ package ethclient
 import (
 	"context"
 	"fmt"
+	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"github.com/ethereum/go-ethereum/trie"
 	"math/big"
@@ -46,6 +47,16 @@ func (p *txProvider) getTxsAtBlock(ctx context.Context, header *types.Header) ([
 	}
 
 	return indexedTxs, err
+}
+
+// getTransactionTrace retrieves the transaction trace
+// with a pre-state tracer for the specified transaction
+// hash.
+//
+// The prestate tracer returns the accounts necessary to
+// execute the specified transaction.
+func (p *txProvider) getTransactionTrace(ctx context.Context, txHash common.Hash) (*TransactionTrace, error) {
+	return p.c.GetTransactionTrace(ctx, txHash)
 }
 
 // createAccessList creates an access list for the

--- a/execution/ethclient/types.go
+++ b/execution/ethclient/types.go
@@ -49,6 +49,11 @@ func (t *TransactionTrace) UnmarshalJSON(data []byte) error {
 			}
 
 			trace.Storage = &storage
+		} else {
+			// No storage slots are touched
+			trace.Storage = &StorageTrace{
+				Slots: make([]common.Hash, 0),
+			}
 		}
 
 		t.Accounts = append(t.Accounts, trace)
@@ -59,16 +64,14 @@ func (t *TransactionTrace) UnmarshalJSON(data []byte) error {
 
 // AccountTrace represents an Ethereum account
 // that was touched during a transaction trace.
-//
-// Note that the storage trace is optional, i.e.,
-// nil if no storage slots were touched.
 type AccountTrace struct {
 	Address common.Address
 	Storage *StorageTrace
 }
 
 // StorageTrace represents the touched storage
-// slots of an account during a transaction trace.
+// slots of an account during a transaction trace,
+// the slots may be empty.
 type StorageTrace struct {
 	Slots []common.Hash
 }

--- a/execution/ethclient/types.go
+++ b/execution/ethclient/types.go
@@ -1,6 +1,8 @@
 package ethclient
 
 import (
+	"encoding/json"
+	"fmt"
 	"github.com/ethereum/go-ethereum/common"
 	"github.com/ethereum/go-ethereum/core/types"
 	"math/big"
@@ -15,6 +17,71 @@ type Account struct {
 	Balance     *big.Int
 	CodeHash    common.Hash
 	StorageRoot common.Hash
+}
+
+// TransactionTrace represents a transaction trace
+// that contains all accounts touched during the
+// transaction execution.
+type TransactionTrace struct {
+	Accounts []*AccountTrace
+}
+
+func (t *TransactionTrace) UnmarshalJSON(data []byte) error {
+	var rawTrace map[string]json.RawMessage
+	if err := json.Unmarshal(data, &rawTrace); err != nil {
+		return err
+	}
+
+	for acc, rawFields := range rawTrace {
+		var fields map[string]json.RawMessage
+		if err := json.Unmarshal(rawFields, &fields); err != nil {
+			return fmt.Errorf("failed to unmarshal fields of account %s: %w", acc, err)
+		}
+		trace := &AccountTrace{
+			Address: common.HexToAddress(acc),
+		}
+
+		if rawStorage, exists := fields["storage"]; exists {
+			var storage StorageTrace
+			err := json.Unmarshal(rawStorage, &storage)
+			if err != nil {
+				return fmt.Errorf("failed to unmarshal storage for account %s: %w", acc, err)
+			}
+
+			trace.Storage = &storage
+		}
+
+		t.Accounts = append(t.Accounts, trace)
+	}
+
+	return nil
+}
+
+// AccountTrace represents an Ethereum account
+// that was touched during a transaction trace.
+//
+// Note that the storage trace is optional, i.e.,
+// nil if no storage slots were touched.
+type AccountTrace struct {
+	Address common.Address
+	Storage *StorageTrace
+}
+
+// StorageTrace represents the touched storage
+// slots of an account during a transaction trace.
+type StorageTrace struct {
+	Slots []common.Hash
+}
+
+func (t *StorageTrace) UnmarshalJSON(data []byte) error {
+	var rawSlots map[string]string
+	if err := json.Unmarshal(data, &rawSlots); err != nil {
+		return err
+	}
+	for slot := range rawSlots {
+		t.Slots = append(t.Slots, common.HexToHash(slot))
+	}
+	return nil
 }
 
 // TransactionWithIndex wraps a transaction

--- a/execution/monitor/state/preparer_test.go
+++ b/execution/monitor/state/preparer_test.go
@@ -42,6 +42,10 @@ func (p preparerTestProvider) GetCodeAtBlock(ctx context.Context, acc common.Add
 	return nil, nil
 }
 
+func (p preparerTestProvider) GetTransactionTrace(ctx context.Context, txHash common.Hash) (*ethclient.TransactionTrace, error) {
+	return nil, nil
+}
+
 func (p preparerTestProvider) CreateAccessList(ctx context.Context, tx *ethclient.TransactionWithSender, blockNum *big.Int) (*types.AccessList, error) {
 	return p.al, p.err
 }

--- a/execution/monitor/state/verifier_test.go
+++ b/execution/monitor/state/verifier_test.go
@@ -51,6 +51,10 @@ func (t verifierTestProvider) GetCodeAtBlock(context.Context, common.Address, *t
 	return nil, nil
 }
 
+func (t verifierTestProvider) GetTransactionTrace(context.Context, common.Hash) (*ethclient.TransactionTrace, error) {
+	return nil, nil
+}
+
 func (t verifierTestProvider) CreateAccessList(context.Context, *ethclient.TransactionWithSender, *big.Int) (*types.AccessList, error) {
 	return nil, nil
 }

--- a/execution/monitor/state/verifier_test.go
+++ b/execution/monitor/state/verifier_test.go
@@ -31,31 +31,27 @@ type verifierTestProvider struct {
 	err error
 }
 
-func (t verifierTestProvider) GetTxsAtBlock(context.Context, *types.Header) ([]*ethclient.TransactionWithIndex, error) {
+func (t *verifierTestProvider) GetTxsAtBlock(context.Context, *types.Header) ([]*ethclient.TransactionWithIndex, error) {
 	return nil, nil
 }
 
-func (t verifierTestProvider) GetLogsAtBlock(context.Context, common.Address, *big.Int) ([]*types.Log, error) {
+func (t *verifierTestProvider) GetLogsAtBlock(context.Context, common.Address, *big.Int) ([]*types.Log, error) {
 	return nil, nil
 }
 
-func (t verifierTestProvider) GetAccountAtBlock(context.Context, common.Address, *types.Header) (*ethclient.Account, error) {
+func (t *verifierTestProvider) GetAccountAtBlock(context.Context, common.Address, *types.Header) (*ethclient.Account, error) {
 	return t.acc, t.err
 }
 
-func (t verifierTestProvider) GetStorageAtBlock(context.Context, common.Address, common.Hash, *types.Header) ([]byte, error) {
+func (t *verifierTestProvider) GetStorageAtBlock(context.Context, common.Address, common.Hash, *types.Header) ([]byte, error) {
 	return t.storage, t.err
 }
 
-func (t verifierTestProvider) GetCodeAtBlock(context.Context, common.Address, *types.Header) ([]byte, error) {
+func (t *verifierTestProvider) GetCodeAtBlock(context.Context, common.Address, *types.Header) ([]byte, error) {
 	return nil, nil
 }
 
-func (t verifierTestProvider) GetTransactionTrace(context.Context, common.Hash) (*ethclient.TransactionTrace, error) {
-	return nil, nil
-}
-
-func (t verifierTestProvider) CreateAccessList(context.Context, *ethclient.TransactionWithSender, *big.Int) (*types.AccessList, error) {
+func (t *verifierTestProvider) GetTransactionTrace(context.Context, common.Hash) (*ethclient.TransactionTrace, error) {
 	return nil, nil
 }
 
@@ -128,7 +124,7 @@ func TestVerifier_VerifyUninitializedReads(t *testing.T) {
 		addr := common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 		world.GetNonce(addr)
 
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: nil,
 			err: fmt.Errorf("failed to retrieve account"),
 		}
@@ -166,7 +162,7 @@ func TestVerifier_VerifyUninitializedReads(t *testing.T) {
 		addr := common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 		world.GetNonce(addr)
 
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     addr,
 				Nonce:       1,
@@ -209,7 +205,7 @@ func TestVerifier_VerifyUninitializedReads(t *testing.T) {
 		addr := common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
 		world.GetNonce(addr)
 
-		v := NewVerifier(store, verifierTestProvider{}, logger)
+		v := NewVerifier(store, &verifierTestProvider{}, logger)
 		if err = v.VerifyUninitializedReads(t.Context(), header, world); err != nil {
 			t.Errorf("expected no error, got: %v", err)
 		}
@@ -243,7 +239,7 @@ func TestVerifier_VerifyUninitializedReads(t *testing.T) {
 		slot := common.BigToHash(big.NewInt(1))
 		world.GetState(addr, slot)
 
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     addr,
 				Nonce:       1,
@@ -262,7 +258,7 @@ func TestVerifier_VerifyUninitializedReads(t *testing.T) {
 
 func TestVerifier_VerifyCompleteness(t *testing.T) {
 	t.Run("should return error when account cannot be retrieved", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: nil,
 			err: fmt.Errorf("failed to retrieve account"),
 		}
@@ -289,7 +285,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should succeed when account does not exist", func(t *testing.T) {
-		v := NewVerifier(nil, verifierTestProvider{}, log.New(slog.DiscardHandler))
+		v := NewVerifier(nil, &verifierTestProvider{}, log.New(slog.DiscardHandler))
 
 		acc := &config.AccountConfig{
 			Addr: common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
@@ -312,7 +308,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should return error if account does not exist not in world state", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address: common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 			},
@@ -340,7 +336,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should return error if nonce mismatch", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address: common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:   2,
@@ -380,7 +376,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should return error if balance mismatch", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address: common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:   1,
@@ -422,7 +418,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should return error if code hash mismatch", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:  common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:    1,
@@ -467,7 +463,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should return error if storage root mismatch", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:       1,
@@ -514,7 +510,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should succeed if valid EOA", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:       1,
@@ -561,7 +557,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should return error if interaction counter mismatch", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:       1,
@@ -614,7 +610,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should succeed if valid contract account", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:       1,
@@ -667,7 +663,7 @@ func TestVerifier_VerifyCompleteness(t *testing.T) {
 	})
 
 	t.Run("should succeed if contract exists but count slot was not written yet (contract creation)", func(t *testing.T) {
-		testProvider := verifierTestProvider{
+		testProvider := &verifierTestProvider{
 			acc: &ethclient.Account{
 				Address:     common.HexToAddress("0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"),
 				Nonce:       0,


### PR DESCRIPTION
The RPC method `eth_createAccessList` was initially used to analyze which storage slots and accounts are access during a transaction. However, it proved unreliable for transactions that have already been executed on-chain, since it simulates the access list based on the current chain state, not the state at the time of execution. To address this, we now use `debug_traceTransaction` with a `prestateTracer`. 