### PR TITLE
refactor: do not track fee recipient

### DIFF
--- a/execution/monitor/state/preparer.go
+++ b/execution/monitor/state/preparer.go
@@ -96,7 +96,9 @@ func (p *Preparer) FilterTxs(ctx context.Context, header *types.Header, txs []*e
 				trackedAccs[*tx.Tx.To()] = true
 			}
 			for _, acc := range tx.Trace.Accounts {
-				trackedAccs[acc.Address] = true
+				if acc.Address != header.Coinbase {
+					trackedAccs[acc.Address] = true
+				}
 			}
 		}
 	}


### PR DESCRIPTION
The fee recipient is recorded in every transaction trace within a block. Monitoring this account is not necessary for our use case. This change reduces the set of tracked accounts and, consequently, the size of the partial state needed to re-execute the transactions of interest.