### PR TITLE
fix: add missing env variable in docker compose

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,4 +13,5 @@ services:
       - DB_PATH=/app/sparseth/.db
       - CONFIG_PATH=/app/config.yaml
       - ETHEREUM_NETWORK=anvil
+      - CHECKPOINT_HASH="0xdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef"
 #      - EVENT_MODE=true # Uncomment to enable event mode


### PR DESCRIPTION
Adds the missing checkpoint hash variable in docker compose which is required when choosing the Anvil network.